### PR TITLE
Built out watchparty component 

### DIFF
--- a/client/components/MainPage.jsx
+++ b/client/components/MainPage.jsx
@@ -9,6 +9,7 @@ import {
   updateMessage,
   updateWatchParty,
 } from '../episodeSlice';
+import WatchParty from './WatchParty.jsx'
 
 const MainPage = () => {
   const dispatch = useDispatch();
@@ -150,6 +151,7 @@ const MainPage = () => {
           </Button>
         </div>
       </Form>
+      <WatchParty/>
     </Container>
   );
 };

--- a/client/components/WatchParty.jsx
+++ b/client/components/WatchParty.jsx
@@ -3,12 +3,15 @@ import { ListGroup } from 'react-bootstrap';
 import '../../client/styles.css';
 import { useSelector, useDispatch } from 'react-redux';
 
+
+
 const WatchParty = () => {
   const stateParty = useSelector((store) => store.episode.watchParty);
   const party = [];
   const maxCache = {};
   const watchList = [];
   const me = useSelector((store) => store.login.username);
+  let header = <></>;
 
   stateParty.forEach((el) => {
     //create a value to index viewer's progress in a series
@@ -43,9 +46,14 @@ const WatchParty = () => {
       );
     }
   });
+
+  if(watchList.length > 0){
+    header = <h3>WATCH PARTY</h3>
+  };
+  
   return (
     <div>
-      {() => {if(watchList.length > 0){<h3>WATCH PARTY</h3>}}}
+      {header}
       <ListGroup>{watchList}</ListGroup>
     </div>
   );

--- a/client/components/WatchParty.jsx
+++ b/client/components/WatchParty.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { ListGroup } from 'react-bootstrap';
+import '../../client/styles.css';
+import { useSelector, useDispatch } from 'react-redux';
+
+const WatchParty = () => {
+  const stateParty = useSelector((store) => store.episode.watchParty);
+  const party = [];
+  const maxCache = {};
+  const watchList = [];
+  const me = useSelector((store) => store.login.username);
+
+  stateParty.forEach((el) => {
+    //create a value to index viewer's progress in a series
+    const viewOrder = el.season * 1000 + el.episode;
+    //keep a record of the latest episode the viewer has watched
+    maxCache[el.user] === undefined
+      ? (maxCache[el.user] = viewOrder)
+      : (maxCache[el.user] = Math.max(maxCache[el.user], viewOrder));
+    //add the view to the party array along with the viewOrder value
+    party.push({ ...el, viewOrder });
+  });
+
+  party.sort((a, b) => a.viewOrder - b.viewOrder);
+
+  const relativeStatus = (el) => {
+    let variant = '';
+    el.user === me
+      ? (variant = 'primary')
+      : el.viewOrder > maxCache[me]
+      ? (variant = 'danger')
+      : (variant = 'success');
+
+    return variant
+  };
+
+  party.forEach((el) => {
+    if (el.viewOrder === maxCache[el.user]) {
+      watchList.push(
+        <ListGroup.Item variant = {relativeStatus(el)}>
+          {`${el.user} - watched up to S${el.season}, Ep ${el.episode}`}
+        </ListGroup.Item>
+      );
+    }
+  });
+  return (
+    <div>
+      {() => {if(watchList.length > 0){<h3>WATCH PARTY</h3>}}}
+      <ListGroup>{watchList}</ListGroup>
+    </div>
+  );
+};
+
+export default WatchParty;

--- a/client/episodeSlice.js
+++ b/client/episodeSlice.js
@@ -6,7 +6,7 @@ const initialState =  {
     season: "",
     episode: "",
     message: "",
-    watchParty: {}
+    watchParty: []
 }
 
 const episodeSlice = createSlice({

--- a/client/main.js
+++ b/client/main.js
@@ -11,7 +11,7 @@ import LoginForm from './components/LoginForm.jsx';
 import MainPage from './components/MainPage.jsx';
 
 //to include bootstrap styling uncomment this line:
-//import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
+import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
 
 
 const router = createBrowserRouter(

--- a/client/main.js
+++ b/client/main.js
@@ -10,6 +10,9 @@ import ShowSelection from './components/ShowSelection.jsx';
 import LoginForm from './components/LoginForm.jsx';
 import MainPage from './components/MainPage.jsx';
 
+//to include bootstrap styling uncomment this line:
+//import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
+
 
 const router = createBrowserRouter(
   [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.6",
+        "bootstrap": "^5.3.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "html-webpack-plugin": "^5.6.0",
@@ -2910,6 +2911,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.6",
+    "bootstrap": "^5.3.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "html-webpack-plugin": "^5.6.0",


### PR DESCRIPTION
- renders upon response from server after saveView
- sorts the watch list by episode order
- only renders the latest view for each user
- adds a variant for the list items based on whether the view is before or after current user
- optional bootstrap styling is accessible by uncommenting bootstrap styling line in main.js 

known issues:
- the view saved during the saveView is not included in the list, we could add locally through a reducer dispatch or add to the database by including insert queries in the /saveview endpoint
- currently serving up all views of all shows, we could filter to just be the show saved by tweaking the /saveview query to only include views for a particular show, or by filtering out other shows as part of the rendering logic.
- react bootstrap styling creates conflicts with other styling in the app and is therefore commented out. Without that styling presentation of this list is very plain.